### PR TITLE
Fixed broken "warning signs" list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Source: http://junit.sourceforge.net/doc/testinfected/testing.htm
 ### Flaw #3: Brittle Global State & Singletons
 #### Warning Signs
 * Adding or using singletons
-* Adding or using static fields or static methods Adding or using static initialization blocks Adding or using registries
+* Adding or using static fields or static methods
+* Adding or using static initialization blocks
+* Adding or using registries
 * Adding or using service locators
 
 ###Flaw #4: Class Does Too Much

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Source: http://junit.sourceforge.net/doc/testinfected/testing.htm
 ####Warning Signs
 
 * Summing up what the class does includes the word “and”
-* Class would be challenging for new team members to read and quickly “get it” Class has fields that are only used in some methods
+* Class would be challenging for new team members to read and quickly “get it”
+* Class has fields that are only used in some methods
 * Class has static methods that only operate on parameters
 
 Source: http://misko.hevery.com/code-reviewers-guide/


### PR DESCRIPTION
The list was something like this:
- Adding X is bad
- Adding Y is bad
- Adding Z is bad Adding Foo is bad Adding Bar is bad
- Adding Baz is bad

So I simply added the required new list elements to make it more like:
- Adding X is bad
- Adding Y is bad
- Adding Z is bad
- Adding Foo is bad
- Adding Bar is bad
- Adding Baz is bad
